### PR TITLE
Fix typo on the code example

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ class MyBot < Telegant::Bot
   def on_greet(update, bot)
     bot.reply("Hey there!")
   end
+end
 
 bot = MyBot.new("YOUR_BOT_TOKEN")
 bot.start()


### PR DESCRIPTION
## Description

The last `end` keyword was missing in the code example.